### PR TITLE
Add indent function arguments rule

### DIFF
--- a/docs/rules/indent-function-args.md
+++ b/docs/rules/indent-function-args.md
@@ -1,0 +1,40 @@
+# Check for function args proper indentation. (indent-function-args)
+
+## Rule Details
+
+Check if function arguments are properly indented according to google js
+styleguide.
+
+The following patterns are considered warnings:
+
+```js
+
+// Indent at 4 spaces.
+foobar(arg1,
+    arg2,
+      arg3);
+
+// Indent at parent parenthesis.
+foobar(arg1,
+       arg2,
+    arg3);
+```
+
+The following patterns are not warnings:
+
+```js
+foo(arg1, arg2);
+
+foobar(arg1,
+    arg2);
+
+foo(arg1,
+    arg2);
+
+foobar(arg1,
+    arg2,
+    arg3);
+
+var foo = bar(arg1, arg2,
+    arg3, arg4);
+```

--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@
 // import all rules in lib/rules
 module.exports = {
   rules: {
+    'indent-function-args': require('./lib/rules/indent-function-args')
   },
   rulesConfig: {
+    'indent-function-args': 0
   }
 };

--- a/lib/get-node-indent.js
+++ b/lib/get-node-indent.js
@@ -1,0 +1,27 @@
+/* Code adapted from https://github.com/eslint/eslint/blob/master/lib/rules/indent.js */
+
+module.exports = function getNodeIndent(node, byLastLine, excludeCommas,
+    indentType, context) {
+  /**
+  * Get node indent
+  *
+  * @param {ASTNode|Token} node Node to examine
+  * @param {boolean} [byLastLine=false] get indent of node's last line
+  * @param {boolean} [excludeCommas=false] skip comma on start of line
+  * @returns {int} Indent
+  */
+  var token = byLastLine ? context.getLastToken(node)
+                         : context.getFirstToken(node),
+      src = context.getSource(token, token.loc.start.column),
+      skip = excludeCommas ? ',' : '',
+      regExp;
+
+  if (indentType === 'space') {
+    regExp = new RegExp('^[ ' + skip + ']+');
+  } else {
+    regExp = new RegExp('^[\t' + skip + ']+');
+  }
+
+  var indent = regExp.exec(src);
+  return indent ? indent[0].length : 0;
+};

--- a/lib/rules/indent-function-args.js
+++ b/lib/rules/indent-function-args.js
@@ -6,11 +6,7 @@
  */
 'use strict';
 var getNodeIndent = require('../get-node-indent.js');
-var indentSize = 4;
-
-//------------------------------------------------------------------------------
-// Rule Definition
-//------------------------------------------------------------------------------
+var INDENT_SIZE = 4;
 
 module.exports = function(context) {
 
@@ -31,7 +27,7 @@ module.exports = function(context) {
       at4spacesFromFunctionCall = {
         accepts: function(node, parent) {
           /**
-           * Checks if argument is correctly alligned at indentSize from parent
+           * Checks if argument is correctly alligned at INDENT_SIZE from parent
            * function call.
            *
            * @return {Boolean}
@@ -39,13 +35,13 @@ module.exports = function(context) {
           var argStartCol = node.loc.start.column,
               functionStartCol = parent.loc.start.column;
 
-          return argStartCol === functionStartCol + indentSize;
+          return argStartCol === functionStartCol + INDENT_SIZE;
         }
       },
       at4spacesFromPrevLineIndent = {
         accepts: function(node, parent) {
           /**
-           * Checks if argument is correctly alligned at indentSize from prev
+           * Checks if argument is correctly alligned at INDENT_SIZE from prev
            * line indent.
            *
            * @return {Boolean}
@@ -54,7 +50,7 @@ module.exports = function(context) {
               functionIndent = getNodeIndent(parent, false, false, 'space',
                   context);
 
-          return argStartCol === functionIndent + indentSize;
+          return argStartCol === functionIndent + INDENT_SIZE;
         }
       };
 
@@ -75,7 +71,7 @@ module.exports = function(context) {
       context.report({
         node: node,
         message: 'Wrong argument indentation. Expected {{ requiredIndent }} ' +
-            'spaces but found {{ actualIndent }}.',
+                 'spaces but found {{ actualIndent }}.',
         data: {
           requiredIndent: requiredIndentation,
           actualIndent: actualIndentation
@@ -84,7 +80,10 @@ module.exports = function(context) {
     } else {
       context.report({
         node: node,
-        message: 'Indent at 4 spaces or parenthesis.'
+        message: 'Indent at {{ indentSize }} 4 spaces or parenthesis.',
+        data: {
+          indentSize: INDENT_SIZE
+        }
       });
     }
   }
@@ -107,13 +106,14 @@ module.exports = function(context) {
           previousLine = functionLine,
           requiredIndentation = null;
 
-      node.arguments.forEach(function(argNode) {
+      node.arguments.forEach(function checkIndent(argNode) {
         var newIndentation,
             childLine = argNode.loc.start.line;
 
         // We need to indent.
         if (previousLine !== childLine) {
           newIndentation = argNode.loc.start.column;
+
           if (!requiredIndentation) {
             requiredIndentation = getIndentationMode(argNode, node);
             if (!requiredIndentation) {
@@ -126,6 +126,7 @@ module.exports = function(context) {
             reportError(argNode, newIndentation, requiredIndentation);
           }
         }
+
         previousLine = argNode.loc.end.line;
       });
     }

--- a/lib/rules/indent-function-args.js
+++ b/lib/rules/indent-function-args.js
@@ -40,7 +40,6 @@ var allignedWithParen = {
 
         return argStartCol === functionEndCol + 1;
       }
-
     },
     at4spacesFromFunctionCall = {
       accepts: function(node, parent) {
@@ -100,7 +99,7 @@ module.exports = function(context) {
     } else {
       context.report({
         node: node,
-        message: 'Indent at {{ indentSize }} 4 spaces or parenthesis.',
+        message: 'Indent at {{ indentSize }} spaces or parenthesis.',
         data: {
           indentSize: INDENT_SIZE
         }

--- a/lib/rules/indent-function-args.js
+++ b/lib/rules/indent-function-args.js
@@ -1,0 +1,150 @@
+/**
+ * @fileoverview Check for function args proper indentation.
+ * @author uberVU
+ * @copyright 2015 uberVU. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+'use strict';
+var _ = require('lodash');
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+  // variables should be defined here
+  var indentMode = 0;
+
+  //--------------------------------------------------------------------------
+  // Helpers
+  //--------------------------------------------------------------------------
+
+  function getNodeIndent(node, byLastLine, excludeCommas, indentType) {
+    /**
+    * Get node indent
+    *
+    * @param {ASTNode|Token} node Node to examine
+    * @param {boolean} [byLastLine=false] get indent of node's last line
+    * @param {boolean} [excludeCommas=false] skip comma on start of line
+    * @returns {int} Indent
+    */
+    var token = byLastLine ? context.getLastToken(node)
+                           : context.getFirstToken(node),
+        src = context.getSource(token, token.loc.start.column),
+        skip = excludeCommas ? ',' : '',
+        regExp;
+
+    if (indentType === 'space') {
+      regExp = new RegExp('^[ ' + skip + ']+');
+    } else {
+      regExp = new RegExp('^[\t' + skip + ']+');
+    }
+
+    var indent = regExp.exec(src);
+    return indent ? indent[0].length : 0;
+  }
+
+  function reportError(node, context) {
+    /**
+    * Reports error for node and indentMode
+    *
+    * @param {ASTNode|Token} node Node to examine
+    * @param {Object} context Rule context object.
+    */
+
+    switch (indentMode) {
+      case 'spaces':
+      case 'line':
+        context.report({
+          node: node,
+          message: 'Indent at 4 spaces.'
+        });
+        break;
+      case 'paren':
+        context.report({
+          node: node,
+          message: 'Indent at parent parenthesis.'
+        });
+        break;
+      default:
+        context.report({
+          node: node,
+          message: 'Indent at 4 spaces or paren.'
+        });
+    }
+  }
+
+  function checkIndent(mode) {
+    /**
+    * Checks the prev indentation (indentMode) against the current one (mode)
+    *
+    * @param {String} mode Current indentation mode.
+    *     Can be 'line', 'paren', 'spaces'.
+    * @param {String} indentMode The indentation that should be enforced across
+    *     all other arguments. Can be 'line', 'paren', 'spaces' and by default
+    *     0 (unset).
+    *
+    * @return {Boolean} Returns true if argument is ok indented or false if not.
+    */
+    switch (indentMode) {
+      case 0:
+        indentMode = mode;
+        break;
+      case mode:
+        break;
+      default:
+        return false;
+    }
+    return true;
+  }
+  //--------------------------------------------------------------------------
+  // Public
+  //--------------------------------------------------------------------------
+
+  return {
+
+    CallExpression: function(node) {
+      var functionStartCol = node.loc.start.column,
+          functionEndCol = node.callee.loc.end.column,
+          functionLine = node.callee.loc.end.line,
+          functionIndent = getNodeIndent(node, false, false, 'space'),
+          previousLine = functionLine;
+
+      indentMode = 0;
+      _.forEach(node.arguments, function(argNode) {
+        var childStartCol = argNode.loc.start.column,
+            childLine = argNode.loc.start.line,
+            okIndent = false;
+
+        // We need to indent.
+        if (previousLine !== childLine) {
+          switch (childStartCol) {
+            // Check if 4 spaces from prev indent.
+            case functionIndent + 4:
+              okIndent = checkIndent('line');
+              break;
+            // Check if 4 spaces.
+            case functionStartCol + 4:
+              okIndent = checkIndent('spaces');
+              break;
+            // Check if paren.
+            case functionEndCol + 1:
+              okIndent = checkIndent('paren');
+              break;
+          }
+          if (!okIndent) {
+            reportError(argNode, context);
+          }
+        }
+        previousLine = argNode.loc.end.line;
+      });
+
+    }
+
+  };
+
+};
+
+module.exports.schema = [
+  // fill in your schema
+];

--- a/lib/rules/indent-function-args.js
+++ b/lib/rules/indent-function-args.js
@@ -108,15 +108,15 @@ module.exports = function(context) {
   }
 
   function getIndentationMode(node, parent) {
-    var argIndenation = node.loc.start.column,
-        returnIndentation = null;
-    indentModes.forEach(function(mode) {
-      if (mode.accepts(node, parent, context)) {
-        returnIndentation = argIndenation;
-      }
-    });
+    var argIndenation = node.loc.start.column;
 
-    return returnIndentation;
+    for (var i = 0; i < indentModes.length; i++) {
+      if (indentModes[i].accepts(node, parent, context)) {
+        return argIndenation;
+      }
+    }
+
+    return null;
   }
 
   return {
@@ -135,13 +135,12 @@ module.exports = function(context) {
 
           if (!requiredIndentation) {
             requiredIndentation = getIndentationMode(argNode, node);
-            if (!requiredIndentation) {
-              reportError(argNode, null, null);
-            }
           }
 
-          // This line must be aligned in the same way as the previous line.
-          if (newIndentation !== requiredIndentation) {
+          if (!requiredIndentation) {
+            reportError(argNode, null, null);
+          } else if (newIndentation !== requiredIndentation) {
+            // This line must be aligned in the same way as the previous line.
             reportError(argNode, newIndentation, requiredIndentation);
           }
         }

--- a/lib/rules/indent-function-args.js
+++ b/lib/rules/indent-function-args.js
@@ -5,146 +5,129 @@
  * See LICENSE file in root directory for full license.
  */
 'use strict';
-var _ = require('lodash');
+var getNodeIndent = require('../get-node-indent.js');
+var indentSize = 4;
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
 
-  // variables should be defined here
-  var indentMode = 0;
+  var allignedWithParen = {
+        accepts: function(node, parent) {
+          /**
+           * Checks if argument is correctly alligned at parent parenthesis.
+           *
+           * @return {Boolean}
+           */
+          var argStartCol = node.loc.start.column,
+              functionEndCol = parent.callee.loc.end.column;
 
-  //--------------------------------------------------------------------------
-  // Helpers
-  //--------------------------------------------------------------------------
+          return argStartCol === functionEndCol + 1;
+        }
 
-  function getNodeIndent(node, byLastLine, excludeCommas, indentType) {
-    /**
-    * Get node indent
-    *
-    * @param {ASTNode|Token} node Node to examine
-    * @param {boolean} [byLastLine=false] get indent of node's last line
-    * @param {boolean} [excludeCommas=false] skip comma on start of line
-    * @returns {int} Indent
-    */
-    var token = byLastLine ? context.getLastToken(node)
-                           : context.getFirstToken(node),
-        src = context.getSource(token, token.loc.start.column),
-        skip = excludeCommas ? ',' : '',
-        regExp;
+      },
+      at4spacesFromFunctionCall = {
+        accepts: function(node, parent) {
+          /**
+           * Checks if argument is correctly alligned at indentSize from parent
+           * function call.
+           *
+           * @return {Boolean}
+           */
+          var argStartCol = node.loc.start.column,
+              functionStartCol = parent.loc.start.column;
 
-    if (indentType === 'space') {
-      regExp = new RegExp('^[ ' + skip + ']+');
-    } else {
-      regExp = new RegExp('^[\t' + skip + ']+');
-    }
+          return argStartCol === functionStartCol + indentSize;
+        }
+      },
+      at4spacesFromPrevLineIndent = {
+        accepts: function(node, parent) {
+          /**
+           * Checks if argument is correctly alligned at indentSize from prev
+           * line indent.
+           *
+           * @return {Boolean}
+           */
+          var argStartCol = node.loc.start.column,
+              functionIndent = getNodeIndent(parent, false, false, 'space',
+                  context);
 
-    var indent = regExp.exec(src);
-    return indent ? indent[0].length : 0;
-  }
+          return argStartCol === functionIndent + indentSize;
+        }
+      };
 
-  function reportError(node, context) {
+  var indentModes = [
+    at4spacesFromFunctionCall,
+    at4spacesFromPrevLineIndent,
+    allignedWithParen
+  ];
+
+  function reportError(node, actualIndentation, requiredIndentation) {
     /**
     * Reports error for node and indentMode
     *
     * @param {ASTNode|Token} node Node to examine
     * @param {Object} context Rule context object.
     */
-
-    switch (indentMode) {
-      case 'spaces':
-      case 'line':
-        context.report({
-          node: node,
-          message: 'Indent at 4 spaces.'
-        });
-        break;
-      case 'paren':
-        context.report({
-          node: node,
-          message: 'Indent at parent parenthesis.'
-        });
-        break;
-      default:
-        context.report({
-          node: node,
-          message: 'Indent at 4 spaces or paren.'
-        });
+    if (actualIndentation && requiredIndentation) {
+      context.report({
+        node: node,
+        message: 'Wrong argument indentation. Expected {{ requiredIndent }} ' +
+            'spaces but found {{ actualIndent }}.',
+        data: {
+          requiredIndent: requiredIndentation,
+          actualIndent: actualIndentation
+        }
+      });
+    } else {
+      context.report({
+        node: node,
+        message: 'Indent at 4 spaces or parenthesis.'
+      });
     }
   }
 
-  function checkIndent(mode) {
-    /**
-    * Checks the prev indentation (indentMode) against the current one (mode)
-    *
-    * @param {String} mode Current indentation mode.
-    *     Can be 'line', 'paren', 'spaces'.
-    * @param {String} indentMode The indentation that should be enforced across
-    *     all other arguments. Can be 'line', 'paren', 'spaces' and by default
-    *     0 (unset).
-    *
-    * @return {Boolean} Returns true if argument is ok indented or false if not.
-    */
-    switch (indentMode) {
-      case 0:
-        indentMode = mode;
-        break;
-      case mode:
-        break;
-      default:
-        return false;
-    }
-    return true;
+  function getIndentationMode(node, parent) {
+    var argIndenation = node.loc.start.column,
+        returnIndentation = null;
+    indentModes.forEach(function(mode) {
+      if (mode.accepts(node, parent)) {
+        returnIndentation = argIndenation;
+      }
+    });
+
+    return returnIndentation;
   }
-  //--------------------------------------------------------------------------
-  // Public
-  //--------------------------------------------------------------------------
 
   return {
-
     CallExpression: function(node) {
-      var functionStartCol = node.loc.start.column,
-          functionEndCol = node.callee.loc.end.column,
-          functionLine = node.callee.loc.end.line,
-          functionIndent = getNodeIndent(node, false, false, 'space'),
-          previousLine = functionLine;
+      var functionLine = node.callee.loc.end.line,
+          previousLine = functionLine,
+          requiredIndentation = null;
 
-      indentMode = 0;
-      _.forEach(node.arguments, function(argNode) {
-        var childStartCol = argNode.loc.start.column,
-            childLine = argNode.loc.start.line,
-            okIndent = false;
+      node.arguments.forEach(function(argNode) {
+        var newIndentation,
+            childLine = argNode.loc.start.line;
 
         // We need to indent.
         if (previousLine !== childLine) {
-          switch (childStartCol) {
-            // Check if 4 spaces from prev indent.
-            case functionIndent + 4:
-              okIndent = checkIndent('line');
-              break;
-            // Check if 4 spaces.
-            case functionStartCol + 4:
-              okIndent = checkIndent('spaces');
-              break;
-            // Check if paren.
-            case functionEndCol + 1:
-              okIndent = checkIndent('paren');
-              break;
+          newIndentation = argNode.loc.start.column;
+          if (!requiredIndentation) {
+            requiredIndentation = getIndentationMode(argNode, node);
+            if (!requiredIndentation) {
+              reportError(argNode, null, null);
+            }
           }
-          if (!okIndent) {
-            reportError(argNode, context);
+
+          // This line must be aligned in the same way as the previous line.
+          if (newIndentation !== requiredIndentation) {
+            reportError(argNode, newIndentation, requiredIndentation);
           }
         }
         previousLine = argNode.loc.end.line;
       });
-
     }
-
   };
-
 };
-
-module.exports.schema = [
-  // fill in your schema
-];

--- a/lib/rules/indent-function-args.js
+++ b/lib/rules/indent-function-args.js
@@ -8,57 +8,77 @@
 var getNodeIndent = require('../get-node-indent.js');
 var INDENT_SIZE = 4;
 
+/**
+ * Interface for indentation mode.
+ *
+ * @interface indentMode
+ */
+
+ /**
+  * Checks if the indentation mode accepts a node's indentation as correct.
+  *
+  * @function
+  * @name IndentMode#accepts
+  *
+  * @param {ASTNode|Token} node Node to examine
+  * @param {ASTNode|Token} parent Parent node for the (node) param.
+  * @param {Object} context Rule context object.
+  *
+  * @return {Boolean}
+  *
+  */
+
+var allignedWithParen = {
+      accepts: function(node, parent) {
+        /**
+         * Checks if argument is correctly alligned at parent parenthesis.
+         *
+         * @implements {IndentMode}
+         */
+        var argStartCol = node.loc.start.column,
+            functionEndCol = parent.callee.loc.end.column;
+
+        return argStartCol === functionEndCol + 1;
+      }
+
+    },
+    at4spacesFromFunctionCall = {
+      accepts: function(node, parent) {
+        /**
+         * Checks if argument is correctly alligned at INDENT_SIZE from parent
+         * function call.
+         *
+         * @implements {IndentMode}
+         */
+        var argStartCol = node.loc.start.column,
+            functionStartCol = parent.loc.start.column;
+
+        return argStartCol === functionStartCol + INDENT_SIZE;
+      }
+    },
+    at4spacesFromPrevLineIndent = {
+      accepts: function(node, parent, context) {
+        /**
+         * Checks if argument is correctly alligned at INDENT_SIZE from prev
+         * line indent.
+         *
+         * @implements {IndentMode}
+         */
+        var argStartCol = node.loc.start.column,
+            functionIndent = getNodeIndent(parent, false, false, 'space',
+                context);
+
+        return argStartCol === functionIndent + INDENT_SIZE;
+      }
+    };
+
+var indentModes = [
+  at4spacesFromFunctionCall,
+  at4spacesFromPrevLineIndent,
+  allignedWithParen
+];
+
 module.exports = function(context) {
-
-  var allignedWithParen = {
-        accepts: function(node, parent) {
-          /**
-           * Checks if argument is correctly alligned at parent parenthesis.
-           *
-           * @return {Boolean}
-           */
-          var argStartCol = node.loc.start.column,
-              functionEndCol = parent.callee.loc.end.column;
-
-          return argStartCol === functionEndCol + 1;
-        }
-
-      },
-      at4spacesFromFunctionCall = {
-        accepts: function(node, parent) {
-          /**
-           * Checks if argument is correctly alligned at INDENT_SIZE from parent
-           * function call.
-           *
-           * @return {Boolean}
-           */
-          var argStartCol = node.loc.start.column,
-              functionStartCol = parent.loc.start.column;
-
-          return argStartCol === functionStartCol + INDENT_SIZE;
-        }
-      },
-      at4spacesFromPrevLineIndent = {
-        accepts: function(node, parent) {
-          /**
-           * Checks if argument is correctly alligned at INDENT_SIZE from prev
-           * line indent.
-           *
-           * @return {Boolean}
-           */
-          var argStartCol = node.loc.start.column,
-              functionIndent = getNodeIndent(parent, false, false, 'space',
-                  context);
-
-          return argStartCol === functionIndent + INDENT_SIZE;
-        }
-      };
-
-  var indentModes = [
-    at4spacesFromFunctionCall,
-    at4spacesFromPrevLineIndent,
-    allignedWithParen
-  ];
 
   function reportError(node, actualIndentation, requiredIndentation) {
     /**
@@ -92,7 +112,7 @@ module.exports = function(context) {
     var argIndenation = node.loc.start.column,
         returnIndentation = null;
     indentModes.forEach(function(mode) {
-      if (mode.accepts(node, parent)) {
+      if (mode.accepts(node, parent, context)) {
         returnIndentation = argIndenation;
       }
     });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "eslint": "1.5.1",
     "eslint-friendly-formatter": "^1.1.0",
-    "lodash": "^3.10.1",
     "mocha": "^2.0.1",
     "pre-git": "^0.6.2"
   },

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "lint": "eslint --ext .js --format './node_modules/eslint-friendly-formatter' .",
     "test": "mocha"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "eslint": "1.5.1",
     "eslint-friendly-formatter": "^1.1.0",
+    "lodash": "^3.10.1",
     "mocha": "^2.0.1",
     "pre-git": "^0.6.2"
   },

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "lint": "eslint --ext .js --format './node_modules/eslint-friendly-formatter' .",
     "test": "mocha"
   },
+  "peerDependencies": {
+    "eslint": ">=0.8.0"
+  },
   "dependencies": {},
   "devDependencies": {
-    "eslint": "1.5.1",
     "eslint-friendly-formatter": "^1.1.0",
     "mocha": "^2.0.1",
     "pre-git": "^0.6.2"

--- a/test/lib/rules/indent-function-args.js
+++ b/test/lib/rules/indent-function-args.js
@@ -6,85 +6,60 @@
  */
 'use strict';
 
-//------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
 var rule = require('../../../lib/rules/indent-function-args'),
-
     RuleTester = require('eslint').RuleTester;
-
-
-//------------------------------------------------------------------------------
-// Tests
-//------------------------------------------------------------------------------
 
 var ruleTester = new RuleTester();
 ruleTester.run('indent-function-args', rule, {
-
-  valid: [
-    {
-      code: 'foo(arg1, arg2);'
-    },
-    {
-      code: 'foobar(arg1,\n' +
-            '    arg2);'
-    },
-    {
-      code: 'foo(arg1,\n' +
-            '    arg2);'
-    },
-    {
-      code: 'foobar(arg1,\n' +
-            '    arg2,\n' +
-            '    arg3);'
-    },
-    {
-      code: 'foobar(arg1,\n' +
-            '       arg2,\n' +
-            '       arg3);'
-    },
-    {
-      code: 'foobar(arg1,\n' +
-            '       arg2, arg3,\n' +
-            '       arg4,\n' +
-            '       arg5);'
-    },
-    {
-      code: 'var foo = bar(arg1, arg2,\n' +
-            '    arg3, arg4);'
-    },
-    {
-      code: 'foo({\n' +
-            '  a: 2,\n' +
-            '  b: 3\n' +
-            '}, arg2);'
-    }
-  ],
-
-  invalid: [
-    {
-      code: 'foobar(arg1,\n' +
-            '    arg2,\n' +
-            '       arg3);',
-      errors: [{
-        message: 'Indent at 4 spaces.'
-      }]
-    },
-    {
-      code: 'foobar(arg1,\n' +
-            '       arg2,\n' +
-            '    arg3);',
-      errors: [{
-        message: 'Indent at parent parenthesis.'
-      }]
-    },
-    {
-      code: 'var foo = bar(arg1, arg2,\n' +
-            'arg3, arg4);',
-      errors: [{
-        message: 'Indent at 4 spaces or paren.'
-      }]
-    }
-  ]
+  valid: [{
+    code: 'foo(arg1, arg2);'
+  }, {
+    code: 'foobar(arg1,\n' +
+          '    arg2);'
+  }, {
+    code: 'foo(arg1,\n' +
+          '    arg2);'
+  }, {
+    code: 'foobar(arg1,\n' +
+          '    arg2,\n' +
+          '    arg3);'
+  }, {
+    code: 'foobar(arg1,\n' +
+          '       arg2,\n' +
+          '       arg3);'
+  }, {
+    code: 'foobar(arg1,\n' +
+          '       arg2, arg3,\n' +
+          '       arg4,\n' +
+          '       arg5);'
+  }, {
+    code: 'var foo = bar(arg1, arg2,\n' +
+          '    arg3, arg4);'
+  }, {
+    code: 'foo({\n' +
+          '  a: 2,\n' +
+          '  b: 3\n' +
+          '}, arg2);'
+  }],
+  invalid: [{
+    code: 'foobar(arg1,\n' +
+          '    arg2,\n' +
+          '       arg3);',
+    errors: [{
+      message: 'Indent at 4 spaces.'
+    }]
+  }, {
+    code: 'foobar(arg1,\n' +
+          '       arg2,\n' +
+          '    arg3);',
+    errors: [{
+      message: 'Indent at parent parenthesis.'
+    }]
+  }, {
+    code: 'var foo = bar(arg1, arg2,\n' +
+          'arg3, arg4);',
+    errors: [{
+      message: 'Indent at 4 spaces or paren.'
+    }]
+  }]
 });

--- a/test/lib/rules/indent-function-args.js
+++ b/test/lib/rules/indent-function-args.js
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Check for function args proper indentation.
+ * @author uberVU
+ * @copyright 2015 uberVU. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/indent-function-args'),
+
+    RuleTester = require('eslint').RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run('indent-function-args', rule, {
+
+  valid: [
+    {
+      code: 'foo(arg1, arg2);'
+    },
+    {
+      code: 'foobar(arg1,\n' +
+            '    arg2);'
+    },
+    {
+      code: 'foo(arg1,\n' +
+            '    arg2);'
+    },
+    {
+      code: 'foobar(arg1,\n' +
+            '    arg2,\n' +
+            '    arg3);'
+    },
+    {
+      code: 'foobar(arg1,\n' +
+            '       arg2,\n' +
+            '       arg3);'
+    },
+    {
+      code: 'foobar(arg1,\n' +
+            '       arg2, arg3,\n' +
+            '       arg4,\n' +
+            '       arg5);'
+    },
+    {
+      code: 'var foo = bar(arg1, arg2,\n' +
+            '    arg3, arg4);'
+    },
+    {
+      code: 'foo({\n' +
+            '  a: 2,\n' +
+            '  b: 3\n' +
+            '}, arg2);'
+    }
+  ],
+
+  invalid: [
+    {
+      code: 'foobar(arg1,\n' +
+            '    arg2,\n' +
+            '       arg3);',
+      errors: [{
+        message: 'Indent at 4 spaces.'
+      }]
+    },
+    {
+      code: 'foobar(arg1,\n' +
+            '       arg2,\n' +
+            '    arg3);',
+      errors: [{
+        message: 'Indent at parent parenthesis.'
+      }]
+    },
+    {
+      code: 'var foo = bar(arg1, arg2,\n' +
+            'arg3, arg4);',
+      errors: [{
+        message: 'Indent at 4 spaces or paren.'
+      }]
+    }
+  ]
+});

--- a/test/lib/rules/indent-function-args.js
+++ b/test/lib/rules/indent-function-args.js
@@ -46,20 +46,20 @@ ruleTester.run('indent-function-args', rule, {
           '    arg2,\n' +
           '       arg3);',
     errors: [{
-      message: 'Indent at 4 spaces.'
+      message: 'Wrong argument indentation. Expected 4 spaces but found 7.'
     }]
   }, {
     code: 'foobar(arg1,\n' +
           '       arg2,\n' +
           '    arg3);',
     errors: [{
-      message: 'Indent at parent parenthesis.'
+      message: 'Wrong argument indentation. Expected 7 spaces but found 4.'
     }]
   }, {
     code: 'var foo = bar(arg1, arg2,\n' +
-          'arg3, arg4);',
+          'arg3);',
     errors: [{
-      message: 'Indent at 4 spaces or paren.'
+      message: 'Indent at 4 spaces or parenthesis.'
     }]
   }]
 });


### PR DESCRIPTION
## Need

``` gherkin
As a developer
I want to have my function arguments properly indented
So that I can write quality code faster.
```
## Deliverables

A new rule called `indent-function-args`  that will check if function arguments are properly indented as follows:

Case 1 - Indent at 4 spaces

``` js
foobar(arg1,
    arg2);
```

Case 2 - Indent at parenthesis

``` js
foo(arg1,
    arg2);
```

Case 3 - Indent at 4 spaces from previous line indent

``` js
var foo = bar(arg1, arg2,
    arg3, arg4);
```

Case 4 - arg2 is indented at 4 spaces so arg3 should also be indented at 4 spaces. Rule will output error message "Indent at 4 spaces"

``` js
foobar(arg1,
    arg2,
      arg3);
```

Case 5 - arg2 is indented at parenthesis so arg3 should also be indented at parenthesis. Rule will output error message "Indent at parenthesis"

``` js
foobar(arg1,
       arg2,
    arg3);
```

Case 6 - Multiple arguments per line should not affect the rule behaviour.

``` js
foobar(arg1,
       arg2, arg3,
       arg4,
       arg5);
```

Case 7 - Multiple line arguments should not affect the rule behaviour.

``` js
foo({
  a: 2,
  b: 3
}, arg2);
```
## Solution
- [ ] The rule will match for `CallExpression` AST nodes and will check indentation for each of their children (attribute nodes).
  Sample AST node:

``` json
"expression": {
    "type": "CallExpression",
    "callee": {
        "type": "Identifier",
        "name": "foobar"
    },
    "arguments": [
        {
            "type": "Identifier",
            "name": "arg1"
        },
        {
            "type": "Identifier",
            "name": "arg2"
        }
    ]
}
```
- [ ] Write tests to validate implementation (in `test/lib/rules/indent-function-args.js`)
